### PR TITLE
Speed improvement in make_cicero_cds function.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cicero
 Type: Package
 Title: Precict cis-co-accessibility from single-cell chromatin accessibility data
-Version: 1.1.3
+Version: 1.1.4
 Authors@R: c(
     person("Hannah", "Pliner", email = "hpliner@uw.edu", role = c("aut", "cre")), 
     person("Cole", "Trapnell", email = "coletrap@uw.edu", role = c("aut")))

--- a/R/runCicero.R
+++ b/R/runCicero.R
@@ -134,10 +134,10 @@ make_cicero_cds <- function(cds,
   exprs_old <- exprs(cds)
   
   mask <- sapply(seq_len(nrow(cell_sample)), function(x) seq_len(ncol(exprs_old)) %in% cell_sample[x,,drop=FALSE])
-  mask <- Matrix(mask)
+  mask <- Matrix::Matrix(mask)
   new_exprs <- exprs_old %*% mask
   
-  new_exprs <- t(new_exprs)
+  new_exprs <- Matrix::t(new_exprs)
   new_exprs <- as.matrix(new_exprs)
   
   pdata <- pData(cds)

--- a/R/runCicero.R
+++ b/R/runCicero.R
@@ -133,12 +133,12 @@ make_cicero_cds <- function(cds,
   
   exprs_old <- exprs(cds)
   
-  x <- lapply(seq_len(nrow(cell_sample)), function(x) {
-    return(Matrix::rowSums(exprs_old %*%
-                             Matrix::Diagonal(x=seq_len(ncol(exprs_old)) %in%
-                                                cell_sample[x,,drop=FALSE])))})
-
-  new_exprs <- do.call(rbind, x)
+  mask <- sapply(seq_len(nrow(cell_sample)), function(x) seq_len(ncol(exprs_old)) %in% cell_sample[x,,drop=FALSE])
+  mask <- Matrix(mask)
+  new_exprs <- exprs_old %*% mask
+  
+  new_exprs <- t(new_exprs)
+  new_exprs <- as.matrix(new_exprs)
   
   pdata <- pData(cds)
   new_pcols <- "agg_cell"


### PR DESCRIPTION
Profiling showed that in large >1k 10x datasets this function took over an hour to complete due to an expensive operation in the lapply loop. I modified the function to avoid this expensive code path while still obtaining the same matrix.