### PR TITLE
Update runCicero.R

### DIFF
--- a/R/runCicero.R
+++ b/R/runCicero.R
@@ -900,7 +900,7 @@ find_ccan_cutoff <- function(connection_df, tolerance_digits) {
   connection_df <- connection_df[connection_df$coaccess > 0,]
   tolerance <- 10^-(tolerance_digits)
   bottom <- 0
-  top <- 1
+  top <- max(connection_df$coaccess)
   while ((top - bottom) > tolerance) {
     test_val <- bottom + round((top - bottom)/2, digits = tolerance_digits + 1)
     ccan_num_test <- number_of_ccans(connection_df, test_val)


### PR DESCRIPTION
Purpose: Making the internal function `find_ccan_cutoff` robust to data during run time. 

In my (test) case the max 'coaccess' is between 0.5 and 0.6. The internal function `find_ccan_cutoff` will show error at the very first step because it will propose a cutoff that is even greater than the max of the observed data 'coaccess'. As a result,  `number_of_ccans` shows an error (see https://github.com/cole-trapnell-lab/cicero-release/issues/62). 